### PR TITLE
Adjusting RootObject Detection to check in all loaded scenes

### DIFF
--- a/Editor/VRC_Bulk_Upload.cs
+++ b/Editor/VRC_Bulk_Upload.cs
@@ -595,9 +595,33 @@ If something goes wrong just delete the Quest scene and start again.");
         RecordLog("Reset avatars");
     }
 
-    static List<VRCAvatarDescriptor> GetVrchatAvatarsToProcess(bool ignoreQuestCheck = false) {
-        GameObject[] rootObjects = UnityEngine.SceneManagement.SceneManager.GetActiveScene().GetRootGameObjects();
+    static Scene[] GetLoadedScenes() {
+        List<Scene> loadedScenes = new List<Scene>(SceneManager.sceneCount);
+        for (int sceneIndex = 0; sceneIndex < SceneManager.sceneCount; ++sceneIndex)
+        {
+            Scene scene = SceneManager.GetSceneAt(sceneIndex);
+            if (scene.isLoaded) {
+                loadedScenes.Add(scene);
+            }
+        }
+
+        return loadedScenes.ToArray();
+    }
+
+    static GameObject[] GetRootObjectsInAllLoadedScenes() {
+        List<GameObject> rootObjects = new List<GameObject>();
+        var scenes = GetLoadedScenes();
         
+        foreach (var scene in scenes) {
+            var sceneRootObjects = scene.GetRootGameObjects();
+            rootObjects.AddRange(sceneRootObjects);
+        }
+
+        return rootObjects.ToArray();
+    }
+
+    static List<VRCAvatarDescriptor> GetVrchatAvatarsToProcess(bool ignoreQuestCheck = false) {
+        GameObject[] rootObjects = GetRootObjectsInAllLoadedScenes();
         var vrcAvatarDescriptors = new List<VRCAvatarDescriptor>();
 
         foreach (var rootObject in rootObjects) {
@@ -699,7 +723,7 @@ If something goes wrong just delete the Quest scene and start again.");
 // RENDER GUI
 
     void RenderAllAvatarsAndInScene() {
-        GameObject[] rootObjects = UnityEngine.SceneManagement.SceneManager.GetActiveScene().GetRootGameObjects();
+        GameObject[] rootObjects = GetRootObjectsInAllLoadedScenes();
         var hasRenderedAtLeastOne = false;
 
         foreach (var rootObject in rootObjects) {


### PR DESCRIPTION
Instead of using only the active scene. Users with multiple loaded screens will be able to upload any avatars (following all existing conditions for a single scene full of avatars) across all loaded scenes.

![image](https://github.com/user-attachments/assets/17fa5f94-fdda-4685-bae4-477630854842)

In the example screenshot the first fail was because the avatar was over the params limit, the build and uploads were a test of the code in this pull request.