### PR TITLE
Temp Relative Debug Log

### DIFF
--- a/Editor/VRC_Bulk_Upload.cs
+++ b/Editor/VRC_Bulk_Upload.cs
@@ -61,7 +61,7 @@ public class VRC_Bulk_Upload : EditorWindow, IActiveBuildTargetChanged {
 
     // logging
     Vector2 logsScrollPosition;
-    const string logPath = "Assets/PeanutTools/debug.log";
+    const string logPath = "Temp/PeanutTools/BulkUploader/debug.log";
     string lastLogsContents;
 
     // questify
@@ -338,7 +338,18 @@ If something goes wrong just delete the Quest scene and start again.");
         EditorGUI.EndDisabledGroup();
     }
 
+    static void CreateFileIfDoesNotExist(string filePath) {
+        if (File.Exists(filePath))
+            return;
+
+        var fileName = Path.GetFileName(filePath);
+        var fileDirectoryPath = filePath.Replace(fileName, "");
+        Directory.CreateDirectory(fileDirectoryPath);
+    }
+
     static void RecordLog(string message) {
+        CreateFileIfDoesNotExist(logPath);
+
         string timestamp = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
         string logMessage = $"{timestamp} - {message}";
 


### PR DESCRIPTION
Within personal projects that include this project, I have found moving the folder containing these assets causes the system to break due to the directory necessary to the log path not existing. This would place the logging file under a Temp path under a specific subdir for the BulkUploader tool  (creating said directory if needed).